### PR TITLE
Changed webserver's ip from loopback to 0.0.0.0

### DIFF
--- a/Belati.py
+++ b/Belati.py
@@ -380,9 +380,9 @@ class Belati(object):
         gather_company.crawl_company_employee(company_name, proxy_address, self.project_id)
 
     def start_web_server(self):
-        log.console_log("{}Starting Django Web Server at http://127.0.0.1:8000/{}".format(Y, W))
+        log.console_log("{}Starting Django Web Server at http://0.0.0.0:8000/{}".format(Y, W))
         py_bin = self.conf.get_config("Environment", "py_bin")
-        command = "{} web/manage.py runserver".format(py_bin)
+        command = "{} web/manage.py runserver 0.0.0.0:8000".format(py_bin)
         process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE)
         while True:
             output = process.stdout.readline()


### PR DESCRIPTION
I have changed the Django's web server binding address from 127.0.0.1 (loopback) to 0.0.0.0.
Check here to know more about [difference between 127.0.0.1 and 0.0.0.0](https://stackoverflow.com/questions/20778771/what-is-the-difference-between-0-0-0-0-127-0-0-1-and-localhost)

**Advantages by changing to 0.0.0.0:**
- Now Django server will listen on every available network interface on port 8000
- This also helps running Belati on a remote system, and retrieve the results using remote machine's IP address