### PR TITLE
Added dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stretch-slim
+LABEL MAINTAINER "Chandrapal <bnchandrapal@protonmail.com>"
+
+RUN cd /home \
+    && apt-get update \
+    && apt-get install -y git python python-pip nmap exiftool \
+    && git clone https://github.com/aancw/Belati.git \
+    && cd Belati \
+    && git checkout 1a458d38 \
+    && git submodule update --init --recursive --remote \
+    && pip install --upgrade --force-reinstall -r requirements.txt \
+    && echo 'alias belati="python /home/Belati/Belati.py"' >> ~/.bashrc
+
+WORKDIR /home/Belati
+
+EXPOSE 8000


### PR DESCRIPTION
I have just added the dockerfile that uses Debian 9 (stretch-slim) as the base image. Also git checkout has been used explicitly to make sure that the dockerfile implements a tested and stable version of belati.